### PR TITLE
GI-4 Implement Sticky Header 

### DIFF
--- a/apps/green-infrastructure/frontend/src/pages/Navbar.tsx
+++ b/apps/green-infrastructure/frontend/src/pages/Navbar.tsx
@@ -2,27 +2,31 @@ import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import Toolbar from '@mui/material/Toolbar';
 import Container from '@mui/material/Container';
-import c4cLogo from '../images/logos/c4cLogo.png'
-import cityOfBostonLogo from '../images/logos/cityOfBostonLogo.png'
+import c4cLogo from '../images/logos/c4cLogo.png';
+import cityOfBostonLogo from '../images/logos/cityOfBostonLogo.png';
 
 function Navbar() {
-
   return (
-    <AppBar position="static" style={{ height: '109px', backgroundColor: 'rgba(255, 255, 255, 1)' }}>
+    <AppBar
+      position="sticky"
+      style={{ height: '109px', backgroundColor: 'rgba(255, 255, 255, 1)' }}
+    >
       <Container maxWidth="xl" style={{ color: 'grey' }}>
         <Toolbar style={{ paddingTop: '25px', paddingBottom: '25px' }}>
-          <img src={cityOfBostonLogo} style={{ marginTop: '12px', paddingRight: '15px' }} />
+          <img
+            src={cityOfBostonLogo}
+            style={{ marginTop: '12px', paddingRight: '15px' }}
+          />
           <div
             style={{
               borderLeft: '1px solid rgba(0, 0, 0, 1)',
               height: '55px',
               paddingRight: '15px',
-            }} />
+            }}
+          />
           <img src={c4cLogo} />
         </Toolbar>
-        
       </Container>
-      
     </AppBar>
   );
 }


### PR DESCRIPTION
### ℹ️ Issue

Closes #35 

### 📝 Description

Modified the header to stay at the top of the current screen as users scroll, rather than staying at the top of the page.

Briefly list the changes made to the code:
1. Changedthe position prop in AppBar component to be "sticky" rather than "static"

### ✔️ Verification

Scrolled up and down on the GI Boston page to ensure that the header correctly remains at the top of the current view as I scroll.

![image](https://github.com/Code-4-Community/everything/assets/31357414/a31b0d70-96e0-4ca8-a040-a2a65618e9d6)

### 🏕️ (Optional) Future Work / Notes

Depending on how we incorporate a component library, the AppBar component may need to be revisited.