### PR TITLE
GI-5 Make legend box fully collapsible

### DIFF
--- a/apps/green-infrastructure/frontend/src/components/map/MapLegend.tsx
+++ b/apps/green-infrastructure/frontend/src/components/map/MapLegend.tsx
@@ -1,8 +1,9 @@
 import styled from 'styled-components';
 import { Image } from 'antd';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { SITE_STATUS_ROADMAP, SITE_TYPE_ROADMAP } from '../../constants';
 import { CaretDownOutlined, CaretUpOutlined } from '@ant-design/icons';
+import { Collapse } from '@mui/material';
 
 
 
@@ -14,9 +15,16 @@ const MapLegendContainer = styled.div<{ isVisible: boolean }>`
   position: relative;
   transition: height 0.3s ease;
   min-height: ${(props) => (props.isVisible ? '20px' : 'auto')};
-  height: ${(props) => (props.isVisible ? '419px' : 'auto')};
+  height: 419px;
+  overflow: hidden;
 `;
 
+const MapLegendToggleContainer = styled.div<{ isVisible: boolean }>`
+  background: #BDBDBD;
+  width: 435px;
+  height: ${(props) => (props.isVisible ? 'auto' : '35px')};
+  gap: 20px;
+`;
 
 const LegendItem = styled.div`
   width: 100%;
@@ -104,6 +112,8 @@ const MapLegend: React.FC<MapLegendProps> = ({ selectedFeatures, setSelectedFeat
     
 
     return (
+      <>
+      <Collapse in={isVisible}>
       <MapLegendContainer isVisible={isVisible}>
       <h1>Feature Type</h1>
 
@@ -202,10 +212,14 @@ const MapLegend: React.FC<MapLegendProps> = ({ selectedFeatures, setSelectedFeat
     </StyledButton>
   )}
 </LegendItem>
-<ToggleButton onClick={toggleShowLegend}>
+  </MapLegendContainer>
+  </Collapse>
+ <MapLegendToggleContainer>
+  <ToggleButton onClick={toggleShowLegend}>
         {isVisible ? <CaretDownStyled /> : <CaretUpStyled />}
       </ToggleButton>
-  </MapLegendContainer>
+  </MapLegendToggleContainer>
+  </>
   );
 };
 

--- a/apps/green-infrastructure/frontend/src/components/map/MapLegend.tsx
+++ b/apps/green-infrastructure/frontend/src/components/map/MapLegend.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { Image } from 'antd';
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 import { SITE_STATUS_ROADMAP, SITE_TYPE_ROADMAP } from '../../constants';
 import { CaretDownOutlined, CaretUpOutlined } from '@ant-design/icons';
 import { Collapse } from '@mui/material';
@@ -15,15 +15,8 @@ const MapLegendContainer = styled.div<{ isVisible: boolean }>`
   position: relative;
   transition: height 0.3s ease;
   min-height: ${(props) => (props.isVisible ? '20px' : 'auto')};
-  height: 419px;
+  height: ${(props) => (props.isVisible ? '419px' : 'auto')};
   overflow: hidden;
-`;
-
-const MapLegendToggleContainer = styled.div<{ isVisible: boolean }>`
-  background: #BDBDBD;
-  width: 435px;
-  height: ${(props) => (props.isVisible ? 'auto' : '35px')};
-  gap: 20px;
 `;
 
 const LegendItem = styled.div`
@@ -58,9 +51,10 @@ const StyledButton = styled.button<{ isSelected: boolean }>`
 const ToggleButton = styled.button`
   cursor: pointer;
   font-size: 18px;
-  position: absolute;
-  bottom: 5px;
+  bottom: 1px;
   left: 200px;
+  position: absolute;
+  z-index: 1;
 `;
 
 
@@ -113,7 +107,10 @@ const MapLegend: React.FC<MapLegendProps> = ({ selectedFeatures, setSelectedFeat
 
     return (
       <>
-      <Collapse in={isVisible}>
+      <Collapse collapsedSize={28} in={isVisible}>
+      <ToggleButton onClick={toggleShowLegend}>
+        {isVisible ? <CaretDownStyled /> : <CaretUpStyled />}
+      </ToggleButton>
       <MapLegendContainer isVisible={isVisible}>
       <h1>Feature Type</h1>
 
@@ -214,11 +211,6 @@ const MapLegend: React.FC<MapLegendProps> = ({ selectedFeatures, setSelectedFeat
 </LegendItem>
   </MapLegendContainer>
   </Collapse>
- <MapLegendToggleContainer>
-  <ToggleButton onClick={toggleShowLegend}>
-        {isVisible ? <CaretDownStyled /> : <CaretUpStyled />}
-      </ToggleButton>
-  </MapLegendToggleContainer>
   </>
   );
 };

--- a/apps/green-infrastructure/frontend/src/components/map/MapLegend.tsx
+++ b/apps/green-infrastructure/frontend/src/components/map/MapLegend.tsx
@@ -106,7 +106,6 @@ const MapLegend: React.FC<MapLegendProps> = ({ selectedFeatures, setSelectedFeat
     
 
     return (
-      <>
       <Collapse collapsedSize={28} in={isVisible}>
       <ToggleButton onClick={toggleShowLegend}>
         {isVisible ? <CaretDownStyled /> : <CaretUpStyled />}
@@ -211,7 +210,6 @@ const MapLegend: React.FC<MapLegendProps> = ({ selectedFeatures, setSelectedFeat
 </LegendItem>
   </MapLegendContainer>
   </Collapse>
-  </>
   );
 };
 


### PR DESCRIPTION
### :information_source: Issue
Closes #36
### :memo: Description
Write a short summary of what you added. Why is it important? Any member of C4C should be able to read this and understand your contribution -- not just your team members.
Briefly list the changes made to the code:

Used MaterialUI Collapse component and some modified styling on the toggle button to make the map legend collapsible. The collapse toggle is still visible in a small rectangle that matches its height when the legend is minimized.
### :heavy_check_mark: Verification
What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. Provide screenshots of any new components, styling changes, or pages.
<img width="457" alt="Screenshot 2023-09-28 at 1 12 28 PM" src="https://github.com/Code-4-Community/everything/assets/94200103/760eefb8-021c-4edf-baa0-142caf828d96">
<img width="437" alt="Screenshot 2023-09-28 at 1 13 13 PM" src="https://github.com/Code-4-Community/everything/assets/94200103/c8f12b63-4017-4ce0-853a-15baa6853c02">
### :camping: (Optional) Future Work / Notes
Not sure if its ideal to wrap the button in the collapse, the reason this works as of now is because of the collapsedSize field of Collapse which allows a specified chunk of the container within collapse to show from top to bottom. If the text in the container within collapse gets pushed up to the top, this will show (ie the collapse behavior is not responsive, more related to how its currently designed). This might require to separate a container for the button to display when closed or some other conditional rendering if we want to keep the button and legend contents in the same component. 