### PR TITLE
GI-8 - Resize legend box to be smaller

### DIFF
--- a/apps/green-infrastructure/frontend/src/components/map/MapLegend.tsx
+++ b/apps/green-infrastructure/frontend/src/components/map/MapLegend.tsx
@@ -1,8 +1,9 @@
 import styled from 'styled-components';
 import { Image } from 'antd';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { SITE_STATUS_ROADMAP, SITE_TYPE_ROADMAP } from '../../constants';
 import { CaretDownOutlined, CaretUpOutlined } from '@ant-design/icons';
+import { Collapse } from '@mui/material';
 
 
 
@@ -14,9 +15,16 @@ const MapLegendContainer = styled.div<{ isVisible: boolean }>`
   position: relative;
   transition: height 0.3s ease;
   min-height: ${(props) => (props.isVisible ? '20px' : 'auto')};
-  height: ${(props) => (props.isVisible ? '419px' : 'auto')};
+  height: 419px;
+  overflow: hidden;
 `;
 
+const MapLegendToggleContainer = styled.div<{ isVisible: boolean }>`
+  background: #BDBDBD;
+  width: 435px;
+  height: ${(props) => (props.isVisible ? 'auto' : '35px')};
+  gap: 20px;
+`;
 
 const LegendItem = styled.div`
   width: 100%;
@@ -104,6 +112,8 @@ const MapLegend: React.FC<MapLegendProps> = ({ selectedFeatures, setSelectedFeat
     
 
     return (
+      <>
+      <Collapse in={isVisible}>
       <MapLegendContainer isVisible={isVisible}>
       <h1>Feature Type</h1>
 
@@ -202,10 +212,14 @@ const MapLegend: React.FC<MapLegendProps> = ({ selectedFeatures, setSelectedFeat
     </StyledButton>
   )}
 </LegendItem>
-<ToggleButton onClick={toggleShowLegend}>
+  </MapLegendContainer>
+  </Collapse>
+ <MapLegendToggleContainer>
+  <ToggleButton onClick={toggleShowLegend}>
         {isVisible ? <CaretDownStyled /> : <CaretUpStyled />}
       </ToggleButton>
-  </MapLegendContainer>
+  </MapLegendToggleContainer>
+  </>
   );
 };
 

--- a/apps/green-infrastructure/frontend/src/components/map/MapLegend.tsx
+++ b/apps/green-infrastructure/frontend/src/components/map/MapLegend.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { Image } from 'antd';
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 import { SITE_STATUS_ROADMAP, SITE_TYPE_ROADMAP } from '../../constants';
 import { CaretDownOutlined, CaretUpOutlined } from '@ant-design/icons';
 import { Collapse } from '@mui/material';
@@ -15,15 +15,8 @@ const MapLegendContainer = styled.div<{ isVisible: boolean }>`
   position: relative;
   transition: height 0.3s ease;
   min-height: ${(props) => (props.isVisible ? '20px' : 'auto')};
-  height: 419px;
+  height: ${(props) => (props.isVisible ? '419px' : 'auto')};
   overflow: hidden;
-`;
-
-const MapLegendToggleContainer = styled.div<{ isVisible: boolean }>`
-  background: #BDBDBD;
-  width: 435px;
-  height: ${(props) => (props.isVisible ? 'auto' : '35px')};
-  gap: 20px;
 `;
 
 const LegendItem = styled.div`
@@ -58,9 +51,10 @@ const StyledButton = styled.button<{ isSelected: boolean }>`
 const ToggleButton = styled.button`
   cursor: pointer;
   font-size: 18px;
-  position: absolute;
-  bottom: 5px;
+  bottom: 1px;
   left: 200px;
+  position: absolute;
+  z-index: 1;
 `;
 
 
@@ -113,7 +107,10 @@ const MapLegend: React.FC<MapLegendProps> = ({ selectedFeatures, setSelectedFeat
 
     return (
       <>
-      <Collapse in={isVisible}>
+      <Collapse collapsedSize={28} in={isVisible}>
+      <ToggleButton onClick={toggleShowLegend}>
+        {isVisible ? <CaretDownStyled /> : <CaretUpStyled />}
+      </ToggleButton>
       <MapLegendContainer isVisible={isVisible}>
       <h1>Feature Type</h1>
 
@@ -214,11 +211,6 @@ const MapLegend: React.FC<MapLegendProps> = ({ selectedFeatures, setSelectedFeat
 </LegendItem>
   </MapLegendContainer>
   </Collapse>
- <MapLegendToggleContainer>
-  <ToggleButton onClick={toggleShowLegend}>
-        {isVisible ? <CaretDownStyled /> : <CaretUpStyled />}
-      </ToggleButton>
-  </MapLegendToggleContainer>
   </>
   );
 };

--- a/apps/green-infrastructure/frontend/src/components/map/MapLegend.tsx
+++ b/apps/green-infrastructure/frontend/src/components/map/MapLegend.tsx
@@ -15,7 +15,7 @@ const MapLegendContainer = styled.div<{ isVisible: boolean }>`
   position: relative;
   transition: height 0.3s ease;
   min-height: ${(props) => (props.isVisible ? '20px' : 'auto')};
-  height: ${(props) => (props.isVisible ? '380px' : 'auto')};
+  height: ${(props) => (props.isVisible ? '360px' : 'auto')};
   overflow: hidden;
 `;
 
@@ -36,7 +36,7 @@ const LegendImage = styled(Image)`
 
 const StyledButton = styled.button<{ isSelected: boolean }>`
   background-color: ${(props) => (props.isSelected ? '#e74c3c' : '#3498db')};
-  height: 38px;
+  height: 35px;
   width: 370px;
   color: #fff;
   border: line;

--- a/apps/green-infrastructure/frontend/src/components/map/MapLegend.tsx
+++ b/apps/green-infrastructure/frontend/src/components/map/MapLegend.tsx
@@ -10,12 +10,12 @@ import { Collapse } from '@mui/material';
 
 const MapLegendContainer = styled.div<{ isVisible: boolean }>`
   background: #BDBDBD;
-  width: 435px;             
+  width: 370px;           
   gap: 20px;
   position: relative;
   transition: height 0.3s ease;
   min-height: ${(props) => (props.isVisible ? '20px' : 'auto')};
-  height: ${(props) => (props.isVisible ? '419px' : 'auto')};
+  height: ${(props) => (props.isVisible ? '380px' : 'auto')};
   overflow: hidden;
 `;
 
@@ -52,7 +52,6 @@ const ToggleButton = styled.button`
   cursor: pointer;
   font-size: 18px;
   bottom: 1px;
-  left: 200px;
   position: absolute;
   z-index: 1;
 `;
@@ -106,7 +105,11 @@ const MapLegend: React.FC<MapLegendProps> = ({ selectedFeatures, setSelectedFeat
     
 
     return (
-      <Collapse collapsedSize={28} in={isVisible}>
+      <Collapse sx={
+        {
+          textAlign: 'center'
+        }
+      } collapsedSize={28} in={isVisible}>
       <ToggleButton onClick={toggleShowLegend}>
         {isVisible ? <CaretDownStyled /> : <CaretUpStyled />}
       </ToggleButton>

--- a/apps/green-infrastructure/frontend/src/components/map/MapLegend.tsx
+++ b/apps/green-infrastructure/frontend/src/components/map/MapLegend.tsx
@@ -106,7 +106,6 @@ const MapLegend: React.FC<MapLegendProps> = ({ selectedFeatures, setSelectedFeat
     
 
     return (
-      <>
       <Collapse collapsedSize={28} in={isVisible}>
       <ToggleButton onClick={toggleShowLegend}>
         {isVisible ? <CaretDownStyled /> : <CaretUpStyled />}
@@ -211,7 +210,6 @@ const MapLegend: React.FC<MapLegendProps> = ({ selectedFeatures, setSelectedFeat
 </LegendItem>
   </MapLegendContainer>
   </Collapse>
-  </>
   );
 };
 

--- a/apps/green-infrastructure/frontend/src/pages/mapPage/MapPage.tsx
+++ b/apps/green-infrastructure/frontend/src/pages/mapPage/MapPage.tsx
@@ -23,7 +23,7 @@ export default function MapPage() {
       <Divider />
       <div style={{ position: 'relative' }}>
         <Map selectedFeatures={selectedFeatures} zoom={8} />
-        <div style={{ position: 'absolute', top: 10, right: 10, zIndex: 100, marginTop: 40 }}>
+        <div style={{ position: 'absolute', top: 10, right: 10, zIndex: 100, marginTop: 50 }}>
           <MapLegend selectedFeatures={selectedFeatures} setSelectedFeatures={setSelectedFeatures} icons={icons} />
         </div>
         <div style={{ position: 'absolute', top: 10, left: 10, zIndex: 100 }}>

--- a/apps/green-infrastructure/frontend/src/pages/mapPage/MapPage.tsx
+++ b/apps/green-infrastructure/frontend/src/pages/mapPage/MapPage.tsx
@@ -23,7 +23,7 @@ export default function MapPage() {
       <Divider />
       <div style={{ position: 'relative' }}>
         <Map selectedFeatures={selectedFeatures} zoom={8} />
-        <div style={{ position: 'absolute', top: 10, right: 10, zIndex: 100 }}>
+        <div style={{ position: 'absolute', top: 10, right: 10, zIndex: 100, marginTop: 40 }}>
           <MapLegend selectedFeatures={selectedFeatures} setSelectedFeatures={setSelectedFeatures} icons={icons} />
         </div>
         <div style={{ position: 'absolute', top: 10, left: 10, zIndex: 100 }}>


### PR DESCRIPTION
### ℹ️ Issue

Closes #44 

### 📝 Description

Write a short summary of what you added. Why is it important? Any member of C4C should be able to read this and understand your contribution -- not just your team members.

I modified the map legend to fit in between the full screen and draggable figure marker icons so that both control icons can now be clicked. This involved:
1. Truncating the map legend container to fit in between both control icons.
2. Applying marginTop to the div that wraps the MapLegend component in MapPage.tsx so that it would be placed under the fullscreen icon
3. Modifying the styledbutton heights to fit in the truncated legend size
4. Added textAlign 'center' to the legend so that the close/open icon was centered, as well as the title of the legend ('Feature Type').

### ✔️ Verification

What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves.

Opening / Closing the legend over and over

<img width="432" alt="Screenshot 2023-10-05 at 12 14 06 AM" src="https://github.com/Code-4-Community/everything/assets/94200103/1531eb6c-d426-49fd-b544-2f446ea6a46b">
<img width="420" alt="Screenshot 2023-10-05 at 12 14 23 AM" src="https://github.com/Code-4-Community/everything/assets/94200103/b42a7ee3-a93c-4053-b3f5-2016dc68bf31">


### 🏕️ (Optional) Future Work / Notes

Pushing the open and close toggle caret to be below all of the feature types. I avoided tackling this for now because I want to verify how many selections we'll need and the optimal size for each selection type for designing the spacing/padding required to separate the toggle from the rest of the content.
