### PR TITLE
GI-11 Match Dropdown to Figma

### DIFF
--- a/apps/green-infrastructure/frontend/src/components/map/MapLegend.tsx
+++ b/apps/green-infrastructure/frontend/src/components/map/MapLegend.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { SITE_STATUS_ROADMAP, SITE_TYPE_ROADMAP } from '../../constants';
 import { CaretDownOutlined, CaretUpOutlined } from '@ant-design/icons';
 import { Collapse } from '@mui/material';
+import ArrowBackIosIcon  from '@mui/icons-material/ArrowBackIos';
 import generateCircleSVG from '../../images/markers/circle';
 import generateDiamondSVG from '../../images/markers/diamond';
 import generateSquareSVG from '../../images/markers/square';
@@ -116,13 +117,18 @@ const StatusButton = styled.button<{ isSelected: boolean }>`
 `;
 
 
-const ToggleButton = styled.button`
+const ToggleContainer = styled.div<{ isVisible: boolean }>`
   cursor: pointer;
   font-size: 18px;
-  bottom: 1px;
-  left: 200px;
   position: absolute;
+  width: 247px;
+  height: 20px;
   z-index: 1;
+  display: flex;
+  justify-content: center;
+  background: #091F2F;
+  bottom: 0px;
+  
 `;
 
 
@@ -190,10 +196,7 @@ const MapLegend: React.FC<MapLegendProps> = ({ selectedFeatures, setSelectedFeat
 
     return (
 
-      <Collapse collapsedSize={28} in={isVisible}>
-      <ToggleButton onClick={toggleShowLegend}>
-        {isVisible ? <CaretDownStyled /> : <CaretUpStyled />}
-      </ToggleButton>
+      <Collapse collapsedSize={20} in={isVisible}>
       <MapLegendContainer isVisible={isVisible}>
       <Title>FEATURE TYPE</Title>
       <Heading>Legend and Description</Heading>
@@ -300,6 +303,12 @@ const MapLegend: React.FC<MapLegendProps> = ({ selectedFeatures, setSelectedFeat
 </LegendItem>
 </StatusContainer>
   </MapLegendContainer>
+  <ToggleContainer isVisible={isVisible} onClick={toggleShowLegend}>
+  {isVisible? <ArrowBackIosIcon  style={{
+    transform: 'translateY(-30%) rotate(-90deg)',
+    color: 'white'}} /> : <ArrowBackIosIcon style={{transform: 'translateY(15%) rotate(90deg)',
+    color: 'white'}} />}
+  </ToggleContainer>
   </Collapse>
   );
 };


### PR DESCRIPTION
### ℹ️ Issue

Closes #50 

### 📝 Description

Write a short summary of what you added. Why is it important? Any member of C4C should be able to read this and understand your contribution -- not just your team members.

This PR matches the legend design for the dropdown in figma, to the one in the application. David and I used material UI icons for the caret, and used direct values for colors and spacing reflected in the figma.

Briefly list the changes made to the code:
1. Changed background color of the caret container to match the navy in the figma.
2. Added styles to ToggleContainer that are conditionally changed when the legend is opened/cl;osed

### ✔️ Verification

What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves.
![Screenshot 2023-10-08 at 2 03 06 PM](https://github.com/Code-4-Community/everything/assets/94200103/b7c6ce6f-c4a8-4927-bcee-1f8e55838a55)
![Screenshot 2023-10-08 at 2 03 29 PM](https://github.com/Code-4-Community/everything/assets/94200103/bce1522d-dd43-4bef-a8b8-606441e7ead4)



### 🏕️ (Optional) Future Work / Notes

Not a lot of future work needed here. Just two things:
1. Caret could be smaller to reflect figma better but the size isn't too large as is
2. Pixel alignment might not be 1:1 with figma, but in terms of responsiveness and look, we believe its centered pretty well
