### PR TITLE
Add minimum age display + filtering

### DIFF
--- a/apps/monarch/monarch-frontend/src/app/ManageTherapists.tsx
+++ b/apps/monarch/monarch-frontend/src/app/ManageTherapists.tsx
@@ -32,6 +32,9 @@ const renderBadges = (therapist: PractitionerInfo) => {
     })),
   ];
 
+  if (therapist.minAgeServed <= 2)
+    badgeList.push({ label: "Serves 2 & Below", colorScheme: 'yellow' })
+
   return badgeList.map((badge, index) => (
     <Badge
       key={index}
@@ -174,6 +177,20 @@ const ManageTherapists: React.FC<{
                             ).toFixed(2) + ' miles away'
                           : 'Unknown'}
                       </Text>
+                    </Box>
+                  </WrapItem>
+                  <WrapItem>
+                    <Box>
+                      <Box
+                        color="gray.500"
+                        fontWeight="bold"
+                        letterSpacing="wide"
+                        fontSize="xs"
+                        textTransform="uppercase"
+                      >
+                        Min. Age Served
+                      </Box>
+                      <Text>{therapist.minAgeServed}</Text>
                     </Box>
                   </WrapItem>
                 </Wrap>

--- a/apps/monarch/monarch-frontend/src/app/ManageTherapists.tsx
+++ b/apps/monarch/monarch-frontend/src/app/ManageTherapists.tsx
@@ -33,7 +33,7 @@ const renderBadges = (therapist: PractitionerInfo) => {
   ];
 
   if (therapist.minAgeServed <= 2)
-    badgeList.push({ label: "Serves 2 & Below", colorScheme: 'yellow' })
+    badgeList.push({ label: "Serves 2 or Below", colorScheme: 'yellow' })
 
   return badgeList.map((badge, index) => (
     <Badge
@@ -188,7 +188,7 @@ const ManageTherapists: React.FC<{
                         fontSize="xs"
                         textTransform="uppercase"
                       >
-                        Min. Age Served
+                        Min. Age Accepted
                       </Box>
                       <Text>{therapist.minAgeServed}</Text>
                     </Box>

--- a/apps/monarch/monarch-frontend/src/app/SearchTherapists.tsx
+++ b/apps/monarch/monarch-frontend/src/app/SearchTherapists.tsx
@@ -271,9 +271,8 @@ const EditButton: React.FC<{
         if (setReload) {
           setReload(true);
         }
+        onEditClose();
       });
-
-      onEditClose();
     }
   };
 

--- a/apps/monarch/monarch-frontend/src/app/SearchTherapists.tsx
+++ b/apps/monarch/monarch-frontend/src/app/SearchTherapists.tsx
@@ -80,7 +80,7 @@ const renderBadges = (therapist: TherapistDisplayModel) => {
   ];
 
   if (therapist.minimumAgeServed <= 2)
-    badgeList.push({ label: "Serves 2 & Below", colorScheme: 'yellow' })
+    badgeList.push({ label: "Serves 2 or Below", colorScheme: 'yellow' })
 
   const now = new Date();
   const joinedDate = new Date(therapist.dateJoined);
@@ -695,7 +695,7 @@ export const SearchTherapists: React.FC<{
                             fontSize="xs"
                             textTransform="uppercase"
                           >
-                            Min. Age Served
+                            Min. Age Accepted
                           </Box>
                           <Text>{therapist.minimumAgeServed}</Text>
                         </Box>

--- a/apps/monarch/monarch-frontend/src/app/SearchTherapists.tsx
+++ b/apps/monarch/monarch-frontend/src/app/SearchTherapists.tsx
@@ -79,6 +79,9 @@ const renderBadges = (therapist: TherapistDisplayModel) => {
     })),
   ];
 
+  if (therapist.minimumAgeServed <= 2)
+    badgeList.push({ label: "Serves 2 & Below", colorScheme: 'yellow' })
+
   const now = new Date();
   const joinedDate = new Date(therapist.dateJoined);
   const monthsDiff =
@@ -401,6 +404,7 @@ export const SearchTherapists: React.FC<{
     searchString: '',
     languages: [],
     maxDistance: 100,
+    minAge: 0,
   });
 
   const [searchResult, setSearchResult] = useState<
@@ -663,6 +667,20 @@ export const SearchTherapists: React.FC<{
                                 ).toFixed(2) + ' miles away'
                               : 'Unknown'}
                           </Text>
+                        </Box>
+                      </WrapItem>
+                      <WrapItem>
+                        <Box>
+                          <Box
+                            color="gray.500"
+                            fontWeight="bold"
+                            letterSpacing="wide"
+                            fontSize="xs"
+                            textTransform="uppercase"
+                          >
+                            Min. Age Served
+                          </Box>
+                          <Text>{therapist.minimumAgeServed}</Text>
                         </Box>
                       </WrapItem>
                     </Wrap>

--- a/apps/monarch/monarch-frontend/src/app/SearchTherapists.tsx
+++ b/apps/monarch/monarch-frontend/src/app/SearchTherapists.tsx
@@ -203,6 +203,7 @@ const EditButton: React.FC<{
   const [familiesHelped, setFamiliesHelped] = useState<number>(
     therapist.familiesHelped
   );
+  const [minAgeServed, setMinAgeServed] = useState<number>(therapist.minimumAgeServed);
   const [dateJoined, setDateJoined] = useState<string>(therapist.dateJoined);
   const [therapyType, setTherapyType] = useState<string>(therapist.therapyType);
   const [businessName, setBusinessName] = useState<string>(therapist.title);
@@ -235,6 +236,7 @@ const EditButton: React.FC<{
     setEmail(therapist.email);
     setWebsite(therapist.website);
     setFamiliesHelped(therapist.familiesHelped);
+    setMinAgeServed(therapist.minimumAgeServed);
     setDateJoined(therapist.dateJoined);
     setTherapyType(therapist.therapyType);
     setBusinessName(therapist.title);
@@ -257,7 +259,7 @@ const EditButton: React.FC<{
         modality: therapyType,
         businessLocation: address,
         businessName: businessName,
-        minAgeServed: therapist.minimumAgeServed,
+        minAgeServed: minAgeServed,
         email: email,
         fullName: fullName,
         languagesList: languages.map((lang) => lang.value),
@@ -331,6 +333,22 @@ const EditButton: React.FC<{
                 />
               </FormControl>
               <FormControl isRequired>
+                <FormLabel>Minimum Age Served</FormLabel>
+                <NumberInput
+                  value={minAgeServed}
+                  onChange={(valueString, valueNumber) =>
+                    setMinAgeServed(valueNumber || 0)
+                  }
+                  min={0}
+                >
+                  <NumberInputField />
+                  <NumberInputStepper>
+                    <NumberIncrementStepper />
+                    <NumberDecrementStepper />
+                  </NumberInputStepper>
+                </NumberInput>
+              </FormControl>
+              <FormControl isRequired>
                 <FormLabel>Languages</FormLabel>
                 <CreatableSelect
                   isMulti
@@ -352,7 +370,7 @@ const EditButton: React.FC<{
                 <NumberInput
                   value={familiesHelped}
                   onChange={(valueString, valueNumber) =>
-                    setFamiliesHelped(valueNumber)
+                    setFamiliesHelped(valueNumber || 0)
                   }
                   min={0}
                 >
@@ -404,7 +422,7 @@ export const SearchTherapists: React.FC<{
     searchString: '',
     languages: [],
     maxDistance: 100,
-    minAge: 0,
+    minAge: 18,
   });
 
   const [searchResult, setSearchResult] = useState<

--- a/apps/monarch/monarch-frontend/src/app/SearchTherapistsFilter.tsx
+++ b/apps/monarch/monarch-frontend/src/app/SearchTherapistsFilter.tsx
@@ -9,6 +9,7 @@ import {
 } from '@chakra-ui/react';
 import LanguageFilter from './components/LanguageFilter';
 import DistanceFilter from './components/DistanceFilter';
+import AgeFilter from './components/AgeFilter';
 
 const SearchTherapistsFilter: React.FC = () => {
   return (
@@ -24,6 +25,7 @@ const SearchTherapistsFilter: React.FC = () => {
         </h2>
         <AccordionPanel pb={4}>
           <LanguageFilter />
+          <AgeFilter />
           <DistanceFilter />
         </AccordionPanel>
       </AccordionItem>

--- a/apps/monarch/monarch-frontend/src/app/actionsController.ts
+++ b/apps/monarch/monarch-frontend/src/app/actionsController.ts
@@ -150,7 +150,7 @@ export function makeActionsController(): ActionsController {
       // Otherwise, filter therapists by any present criteria
       if (query.minAge > 0) {
         therapists = therapists.filter(
-          (practitioner: Therapist) => practitioner.minimumAgeServed >= query.minAge
+          (practitioner: Therapist) => practitioner.minimumAgeServed <= query.minAge
         );
       }
 

--- a/apps/monarch/monarch-frontend/src/app/components/AgeFilter/index.tsx
+++ b/apps/monarch/monarch-frontend/src/app/components/AgeFilter/index.tsx
@@ -11,12 +11,12 @@ import {
   Tooltip,
 } from '@chakra-ui/react';
 
-const AGE_MARKS = [2, 6, 10, 14]
+const AGE_MARKS = [2, 6, 10, 14, 18]
 
 const AgeFilter: React.FC = () => {
   const queryContext = useContext(QueryContext);
   const [showTooltip, setShowTooltip] = useState<boolean>(false);
-  const [minAge, setMinAge] = useState<number>(0);
+  const [minAge, setMinAge] = useState<number>(queryContext?.searchQuery.minAge || 18);
 
   return (
     <Box
@@ -25,13 +25,14 @@ const AgeFilter: React.FC = () => {
       mb='6'
     >
       <Heading size="sm" mb="2">
-        Minimum Age
+        Ages Served
       </Heading>
       <Slider
         id='age-slider'
-        defaultValue={0}
+        defaultValue={18}
         min={0}
         max={18}
+        isReversed
         colorScheme='teal'
         onChange={(minAge: number) => setMinAge(minAge)}
         onChangeEnd={(minAge: number) => 
@@ -44,7 +45,7 @@ const AgeFilter: React.FC = () => {
       >
         {AGE_MARKS.map((mark: number) => (
           <SliderMark value={mark} mt="1" ml="-2.5" fontSize="sm">
-            {mark} years
+            {mark}+ years
           </SliderMark>
         ))}
         <SliderTrack>
@@ -56,7 +57,7 @@ const AgeFilter: React.FC = () => {
           color="white"
           placement="top"
           isOpen={showTooltip}
-          label={`${minAge} years`}
+          label={`${minAge}+ years`}
         >
           <SliderThumb />
         </Tooltip>

--- a/apps/monarch/monarch-frontend/src/app/components/AgeFilter/index.tsx
+++ b/apps/monarch/monarch-frontend/src/app/components/AgeFilter/index.tsx
@@ -19,13 +19,9 @@ const AgeFilter: React.FC = () => {
   const [minAge, setMinAge] = useState<number>(queryContext?.searchQuery.minAge || 18);
 
   return (
-    <Box
-      onMouseEnter={() => setShowTooltip(true)}
-      onMouseLeave={() => setShowTooltip(false)}
-      mb='6'
-    >
+    <Box mb='6'>
       <Heading size="sm" mb="2">
-        Ages Served
+        Ages Accepted
       </Heading>
       <Slider
         id='age-slider'
@@ -41,6 +37,8 @@ const AgeFilter: React.FC = () => {
             minAge,
           }
         )}
+        onMouseEnter={() => setShowTooltip(true)}
+        onMouseLeave={() => setShowTooltip(false)}
         maxW={600}
       >
         {AGE_MARKS.map((mark: number) => (

--- a/apps/monarch/monarch-frontend/src/app/components/AgeFilter/index.tsx
+++ b/apps/monarch/monarch-frontend/src/app/components/AgeFilter/index.tsx
@@ -1,0 +1,68 @@
+import { useContext, useState } from 'react';
+import { QueryContext } from '../../SearchTherapists';
+import {
+  Box,
+  Heading,
+  Slider,
+  SliderFilledTrack,
+  SliderMark,
+  SliderThumb,
+  SliderTrack,
+  Tooltip,
+} from '@chakra-ui/react';
+
+const AGE_MARKS = [2, 6, 10, 14]
+
+const AgeFilter: React.FC = () => {
+  const queryContext = useContext(QueryContext);
+  const [showTooltip, setShowTooltip] = useState<boolean>(false);
+  const [minAge, setMinAge] = useState<number>(0);
+
+  return (
+    <Box
+      onMouseEnter={() => setShowTooltip(true)}
+      onMouseLeave={() => setShowTooltip(false)}
+      mb='6'
+    >
+      <Heading size="sm" mb="2">
+        Minimum Age
+      </Heading>
+      <Slider
+        id='age-slider'
+        defaultValue={0}
+        min={0}
+        max={18}
+        colorScheme='teal'
+        onChange={(minAge: number) => setMinAge(minAge)}
+        onChangeEnd={(minAge: number) => 
+          queryContext?.setSearchQuery({
+            ...queryContext?.searchQuery, 
+            minAge,
+          }
+        )}
+        maxW={600}
+      >
+        {AGE_MARKS.map((mark: number) => (
+          <SliderMark value={mark} mt="1" ml="-2.5" fontSize="sm">
+            {mark} years
+          </SliderMark>
+        ))}
+        <SliderTrack>
+          <SliderFilledTrack />
+        </SliderTrack>
+        <Tooltip
+          hasArrow
+          bg="teal.500"
+          color="white"
+          placement="top"
+          isOpen={showTooltip}
+          label={`${minAge} years`}
+        >
+          <SliderThumb />
+        </Tooltip>
+      </Slider>
+    </Box>
+  );
+};
+
+export default AgeFilter;

--- a/apps/monarch/monarch-frontend/src/app/components/DistanceFilter/index.tsx
+++ b/apps/monarch/monarch-frontend/src/app/components/DistanceFilter/index.tsx
@@ -102,6 +102,7 @@ const DistanceFilter: React.FC = () => {
                 maxDistance: distance,
               })
             }
+            maxW={600}
           >
             <SliderMark value={50} mt="1" ml="-2.5" fontSize="sm">
               50 miles

--- a/apps/monarch/monarch-frontend/src/app/components/LanguageFilter/index.tsx
+++ b/apps/monarch/monarch-frontend/src/app/components/LanguageFilter/index.tsx
@@ -10,10 +10,10 @@ import { QueryContext } from '../../SearchTherapists';
 
 const LanguageFilter: React.FC = () => {
     const queryContext = useContext(QueryContext);
-    const availableLanguages = ['English', 'Spanish', 'Polish', 'Portuguese','Korean', 'French'];
+    const availableLanguages = ['English', 'Spanish', 'Polish', 'Portuguese','Korean', 'French', 'ASL', 'Chinese'];
 
     return (
-        <Box>
+        <Box mb='6'>
             <Heading size='sm' mb='2'>
             Languages
             </Heading>


### PR DESCRIPTION
### ℹ️ Issue

Closes <issue>

### 📝 Description

- Practitioners display their minimum age served
- Adds a badge for minimum age served of <= 2 years

![image](https://github.com/user-attachments/assets/1d888226-d29c-4af4-af60-6bc4f9a84290)

- Add a filter to find minimum age served <= given year
  - The idea here is that a parent would enter the age of their child (or younger), and it excludes any practitioners whose minimum age served is larger than that age, as the parent wouldn't be interested in those practitioners 

![image](https://github.com/user-attachments/assets/f6166285-1bf2-42cb-bd49-03d88bab7d83)



Write a short summary of what you added. Why is it important? Any member of C4C should be able to read this and understand your contribution -- not just your team members.

Briefly list the changes made to the code:
1. Added support for this.
2. And removed redunant use of that.
3. Also this was included for reasons.

### ✔️ Verification

What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves.

Provide screenshots of any new components, styling changes, or pages. 

### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!
